### PR TITLE
Added namelist options and defaults for PPE

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -1065,6 +1065,8 @@ if ($chem =~ /_mam_oslo/) {$aer_model = 'oslo';}
 
 if ($aer_model eq 'oslo') {
    #do nothing here
+   add_default($nl, 'oslo_aero_lifecyclenumbermedianradius');
+
 }
 elsif ($aer_model eq 'mam' ) {
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -1066,6 +1066,10 @@ if ($chem =~ /_mam_oslo/) {$aer_model = 'oslo';}
 if ($aer_model eq 'oslo') {
    #do nothing here
    add_default($nl, 'oslo_aero_lifecyclenumbermedianradius');
+   add_default($nl, 'oslo_aero_lifecyclesigma');
+   add_default($nl, 'oslo_aero_nucl_scaling_factor');
+   add_default($nl, 'oslo_aero_n_so4_monolayers_age');
+   add_default($nl, 'oslo_aero_f_act_conv_interstitial');
 
 }
 elsif ($aer_model eq 'mam' ) {

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1371,9 +1371,12 @@
 
 <seasalt_emis_scale  spcam_clubb_sgs="1" phys="spcam_sam1mom"            >1.00D0</seasalt_emis_scale >
 <seasalt_emis_scale  spcam_clubb_sgs="1" phys="spcam_m2005"              >1.00D0</seasalt_emis_scale >
-<!-- smb: size parameters -->
-    <lifecyclenmr_1>0.025D-6</lifecyclenmr_1>
-    <lifecyclenmr_8>0.0475D-6</lifecyclenmr_8>
+
+<!-- smb: size parameters        -->
+<oslo_aero_lifecyclenumbermedianradius> 0.0626D-6,
+    0.025D-6, 0.025D-6 , 0.04D-6,   0.06D-6,   0.075D-6,
+    0.22D-6,   0.63D-6,  0.0475D-6, 0.30D-6,   0.75D-6,
+    0.0118D-6, 0.024D-6, 0.04D-6  , 0.04D-6  </oslo_aero_lifecyclenumbermedianradius>
 
 <!-- convective scavenging of aerosols -->
 <f_act_conv_coarse_dust>0.40D0</f_act_conv_coarse_dust>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1377,6 +1377,16 @@
     0.025D-6, 0.025D-6 , 0.04D-6,   0.06D-6,   0.075D-6,
     0.22D-6,   0.63D-6,  0.0475D-6, 0.30D-6,   0.75D-6,
     0.0118D-6, 0.024D-6, 0.04D-6  , 0.04D-6  </oslo_aero_lifecyclenumbermedianradius>
+<oslo_aero_lifecyclesigma> 1.6D0,
+    1.8D0, 1.8D0, 1.8D0, 1.8D0,
+    1.59D0, 1.59D0, 2.0D0,
+    2.1D0, 1.72D0, 1.6D0,
+    1.8D0, 1.8D0, 1.8D0, 1.8D0  </oslo_aero_lifecyclesigma>
+
+<oslo_aero_nucl_scaling_factor>1.0D0</oslo_aero_nucl_scaling_factor>
+<oslo_aero_n_so4_monolayers_age>3.0D0</oslo_aero_n_so4_monolayers_age>
+<oslo_aero_f_act_conv_interstitial>0.8D0</oslo_aero_f_act_conv_interstitial>
+
 
 <!-- convective scavenging of aerosols -->
 <f_act_conv_coarse_dust>0.40D0</f_act_conv_coarse_dust>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2647,6 +2647,24 @@ Default: 2.47
     Assumed life cycle number median radius for mixtures 0-14.
     Default: set by built namelist
 </entry>
+<entry id="oslo_aero_lifecyclesigma" type="real(15)" category="microphys"
+       group="oslo_aero_share_nl" valid_values="" >
+    Assumed life cycle number median radius for mixtures 0-14.
+    Default: set by built namelist
+</entry>
+
+
+<entry id="oslo_aero_n_so4_monolayers_age" type="real" category="microphys"
+       group="oslo_aero_condtend_nl" valid_values="" >
+    Number of so4 monolayers before particle counted as aged.
+    Default: set by built namelist
+</entry>
+
+<entry id="oslo_aero_nucl_scaling_factor" type="real" category="microphys"
+       group="oslo_aero_condtend_nl" valid_values="" >
+    Scaling factor for nucleation.
+    Default: 1
+</entry>
 <!-- smb: 2016-06-01: Added new namelist variables for aerosol microphysics -->
 
 <entry id="microp_aero_bulk_scale" type="real" category="microphys"
@@ -4941,6 +4959,12 @@ Default: set by build-namelist.
        group="oslo_aero_depos_nl" valid_values="" >
 Convetive scavenging coefficient for coarse dust
 Default: set by build-namelist.
+</entry>
+
+<entry id="oslo_aero_f_act_conv_interstitial" type="real" category="cam_chem"
+       group="oslo_aero_depos_nl" valid_values="" >
+    Convetive scavenging coefficient for interstitial aerosols
+    Default: 0.8
 </entry>
 
 <entry id="seasalt_emis_scale" type="real" category="cam_chem"

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2642,17 +2642,12 @@ Default: 2.47
 
 <!-- Aerosol microphysics -->
 <!-- smb: 2016-06-01: Added new namelist variables for aerosol microphysics -->
-<entry id="lifecyclenmr_1" type="real" category="microphys"
+<entry id="oslo_aero_lifecyclenumbermedianradius" type="real(15)" category="microphys"
        group="oslo_aero_share_nl" valid_values="" >
-    Assumed life cycle number median radius for mixture 1.
-    Default: 0.025-6 m
+    Assumed life cycle number median radius for mixtures 0-14.
+    Default: set by built namelist
 </entry>
 <!-- smb: 2016-06-01: Added new namelist variables for aerosol microphysics -->
-<entry id="lifecyclenmr_8" type="real" category="microphys"
-       group="oslo_aero_share_nl" valid_values="" >
-    Assumed life cycle number median radius for mixture 8.
-    Default: 0.0475e-6 m
-    </entry>
 
 <entry id="microp_aero_bulk_scale" type="real" category="microphys"
        group="microp_aero_nl" valid_values="" >


### PR DESCRIPTION
- oslo_aero_n_so4_monolayers_age: number of so4 monolayers before particle aged
- oslo_aero_nucl_scaling_factor: scaling factor for  nucleation rate
- oslo_aero_lifeCycleNumberMedianRadius: assumed number median radius for each mixture.
- oslo_aero_lifeCycleSigma: Same as above for sigma
- oslo_aero_f_act_conv_interstitial

Contributors: @sarambl 

Reviewers: @Ovewh 


Changes made to build system: See above

Changes made to the namelist: See above

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

